### PR TITLE
Fix crash from constructor

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,6 +9,7 @@
       "includePath": [
         "${workspaceFolder}/**",
         "${workspaceFolder}/extern/**",
+        "${workspaceFolder}/extern/libil2cpp/il2cpp/libil2cpp",
         "${workspaceFolder}/extern/codegen/include/**",
         "${workspaceFolder}/../android-ndk-r21d/**"
       ],

--- a/Android.mk
+++ b/Android.mk
@@ -33,9 +33,9 @@ LOCAL_CPP_FEATURES += exceptions
 include $(PREBUILT_SHARED_LIBRARY)
 # Creating prebuilt for dependency: codegen - version: 0.3.1
 include $(CLEAR_VARS)
-LOCAL_MODULE := codegen_0_3_5
-LOCAL_EXPORT_C_INCLUDES := extern/codegen/include
-LOCAL_SRC_FILES := extern/libcodegen_0_3_5.so
+LOCAL_MODULE := codegen_0_3_6
+LOCAL_EXPORT_C_INCLUDES := extern/codegen
+LOCAL_SRC_FILES := extern/libcodegen_0_3_6.so
 LOCAL_CPP_FEATURES += exceptions
 include $(PREBUILT_SHARED_LIBRARY)
 # Creating prebuilt for dependency: custom-types - version: 0.2.10
@@ -55,10 +55,10 @@ LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.c)
 LOCAL_SHARED_LIBRARIES += modloader
 LOCAL_SHARED_LIBRARIES += beatsaber-hook_0_8_4
-LOCAL_SHARED_LIBRARIES += codegen_0_3_5
+LOCAL_SHARED_LIBRARIES += codegen_0_3_6
 LOCAL_SHARED_LIBRARIES += custom-types
 LOCAL_LDLIBS += -llog
-LOCAL_CFLAGS += -isystem"./extern/libil2cpp/il2cpp/libil2cpp" -isystem"extern"
+LOCAL_CFLAGS += -isystem"./extern/libil2cpp/il2cpp/libil2cpp" -isystem"extern" -isystem"./extern/codegen/include"
 LOCAL_CPPFLAGS += -std=c++2a
 LOCAL_C_INCLUDES += ./include ./src
 include $(BUILD_SHARED_LIBRARY)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,12 +118,12 @@ MAKE_HOOK_OFFSETLESS(DeserializeFromJSONString, BeatmapSaveData*, Il2CppString *
 CustomJSONData::CustomNoteData* CustomJSONDataCreateBasicNoteData(float time, int lineIndex, NoteLineLayer noteLineLayer, ColorType colorType, NoteCutDirection cutDirection) {
     NELogger::GetLogger().info("Create Basic Note Data");
     NELogger::GetLogger().debug("custom klass: %p", CustomJSONData::CustomNoteData::klass);
-    return CRASH_UNLESS(il2cpp_utils::New<CustomJSONData::CustomNoteData*>(time, lineIndex, noteLineLayer, noteLineLayer, colorType, cutDirection, 0, 0, lineIndex, 0, 0));
+    return CRASH_UNLESS(il2cpp_utils::New<CustomJSONData::CustomNoteData*>(time, lineIndex, noteLineLayer, noteLineLayer, colorType, cutDirection, 0.0f, 0.0f, lineIndex, 0.0f, 0.0f));
 }
 
 CustomJSONData::CustomNoteData* CustomJSONDataCreateBombNoteData(float time, int lineIndex, NoteLineLayer noteLineLayer) {
     
-    return CRASH_UNLESS(il2cpp_utils::New<CustomJSONData::CustomNoteData*>(time, lineIndex, noteLineLayer, noteLineLayer, ColorType::None, NoteCutDirection::None, 0, 0, lineIndex, 0, 0));
+    return CRASH_UNLESS(il2cpp_utils::New<CustomJSONData::CustomNoteData*>(time, lineIndex, noteLineLayer, noteLineLayer, ColorType::None, NoteCutDirection::None, 0.0f, 0.0f, lineIndex, 0.0f, 0.0f));
 }
 
 // This hook creates the CustomNoteData using the custom json data found in the BeatmapSaveData
@@ -252,11 +252,6 @@ extern "C" void load() {
     CRASH_UNLESS(custom_types::Register::RegisterType<CustomJSONData::CustomObstacleData>());
     CRASH_UNLESS(custom_types::Register::RegisterType<CustomJSONData::CustomNoteData>());
     CRASH_UNLESS(custom_types::Register::RegisterType<CustomJSONData::CustomEventData>());
-    
-    // Remove this
-    for (int i = 0; i < custom_types::Register::classes.size(); i++) {
-        NELogger::GetLogger().info("%p", custom_types::Register::classes[i]);
-    }
 
     NELogger::GetLogger().info("Installed NoodleExtensions Hooks!");
 }


### PR DESCRIPTION
As a side note, you should NOT have the utils logger set to silent until you are CERTAIN you don't need it... and possibly not even then.

I left that out of this PR, however. You can fix it at your own discretion, but that was why the macro logs were not appearing (as well as the debugging info surrounding the different method signatures).

I also version bumped your libraries a bit :)