### PR TITLE
Fix detection of maps using both NE and ME

### DIFF
--- a/src/NoodleExtensions.cpp
+++ b/src/NoodleExtensions.cpp
@@ -32,7 +32,7 @@ void InstallAndRegisterAll() {
         bool meRequirement = std::any_of(requirements.begin(), requirements.end(),
                                          [](auto const& s) { return s == NoodleExtensions::U8_ME_REQUIREMENTNAME; });
         bool neRequirement = std::any_of(requirements.begin(), requirements.end(),
-                                         [](auto const& s) { return s == NoodleExtensions::U8_ME_REQUIREMENTNAME; });
+                                         [](auto const& s) { return s == NoodleExtensions::U8_REQUIREMENTNAME; });
 
         for (auto const& r : requirements) {
           NELogger::Logger.debug("Installed on map {}", r.c_str());


### PR DESCRIPTION
Right now it always detects a conflict if a song uses Mapping Extensions.