### PR TITLE
Fixed processing V3 sliders

### DIFF
--- a/include/Constants.hpp
+++ b/include/Constants.hpp
@@ -48,6 +48,7 @@ inline static constexpr const std::string_view LINK = "link";
 inline static constexpr const std::string_view TARGET = "target";
 
 inline static constexpr const std::string_view INTERNAL_STARTNOTELINELAYER = "NE_startNoteLineLayer";
+inline static constexpr const std::string_view INTERNAL_TAILSTARTNOTELINELAYER = "NE_tailStartNoteLineLayer";
 inline static constexpr const std::string_view INTERNAL_FLIPYSIDE = "NE_flipYSide";
 inline static constexpr const std::string_view INTERNAL_FLIPLINEINDEX = "NE_flipLineIndex";
 inline static constexpr const std::string_view INTERNAL_FAKE_NOTE = "NE_fake";


### PR DESCRIPTION
Implemented the V3 logic from `HandleCurrentTimeSliceAllNotesAndSlidersDidFinishTimeSlice`. Both custom placed notes with arcs and default V3 placement now properly assign scoring type achieving parity with PC.

Tested on:
https://beatleader.xyz/leaderboard/global/33647x71/21
https://beatleader.xyz/leaderboard/global/3bef7xxx97/3

Issues I left:
- Placed `Approximately` in the hook file. Where should I put it or maybe there is an existing function equivalent?
- Copy paste logic for reading NE json. I wanted to keep the logic both similar to the game and the previous style so it ended up with a bit of copy-paste. 
- CutDirectionAngleOffset logic from PC. It's absent in the original game code and in quest V2 implementation, so I'm not sure if I need to port it as well.