### PR TITLE
Fixed missed hook installation for custom sliders

### DIFF
--- a/src/Hooks/BeatmapObjectSpawnMovementData.cpp
+++ b/src/Hooks/BeatmapObjectSpawnMovementData.cpp
@@ -220,7 +220,8 @@ MAKE_HOOK_MATCH(GetJumpingNoteSpawnData, &BeatmapObjectSpawnMovementData::GetJum
 void InstallBeatmapObjectSpawnMovementDataHooks() {
   INSTALL_HOOK(NELogger::Logger, GetObstacleSpawnData);
   INSTALL_HOOK(NELogger::Logger, GetJumpingNoteSpawnData);
-  INSTALL_HOOK(NELogger::Logger, BeatmapObjectSpawnController_Start)
+  INSTALL_HOOK(NELogger::Logger, BeatmapObjectSpawnController_Start);
+  INSTALL_HOOK(NELogger::Logger, GetSliderSpawnData)
 }
 
 NEInstallHooks(InstallBeatmapObjectSpawnMovementDataHooks);


### PR DESCRIPTION
This fixes chains with custom coordinates, map for example: https://beatleader.xyz/leaderboard/global/3973677/1
<img width="442" alt="image" src="https://github.com/user-attachments/assets/5abb39e2-5722-4df0-9f79-053abf116ef6">