### PR TITLE
Fix FakeNotes, missing FakeBomb audio-related hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A port of the Noodle Extensions mod made originally for the PC version of Beat S
 - [x] Fix V3 custom event animating offset position
 - [x] Fix notes being double spawned
 - [x] Fix CJD loading arcs and chains
-- [ ] Fix fake notes
+- [x] Fix fake notes
 - [x] Fix CJD VNJS
 - [x] Fix Chroma V2 position and localPosition missing kNoteLinesDistance
 - [ ] Beat Leader is generating invalid, corrupted replays and refrains from uploading them

--- a/src/Hooks/FakeNotes/BadNoteCutEffectSpawner.cpp
+++ b/src/Hooks/FakeNotes/BadNoteCutEffectSpawner.cpp
@@ -3,6 +3,7 @@
 
 #include "GlobalNamespace/GameNoteController.hpp"
 #include "GlobalNamespace/BadNoteCutEffectSpawner.hpp"
+#include "GlobalNamespace/BombCutSoundEffectManager.hpp"
 
 #include "FakeNoteHelper.h"
 #include "NEHooks.h"
@@ -20,7 +21,18 @@ MAKE_HOOK_MATCH(BadNoteCutEffectSpawner_HandleNoteWasCut, &BadNoteCutEffectSpawn
   }
 }
 
+MAKE_HOOK_MATCH(BombCutSoundEffectManager_HandleNoteWasCut, &BombCutSoundEffectManager::HandleNoteWasCut, void,
+                BombCutSoundEffectManager* self, GlobalNamespace::NoteController* noteController,
+                ByRef<GlobalNamespace::NoteCutInfo> noteCutInfo) {
+  if (!Hooks::isNoodleHookEnabled()) return BombCutSoundEffectManager_HandleNoteWasCut(self, noteController, noteCutInfo);
+
+  if (!FakeNoteHelper::GetFakeNote(noteController->noteData)) {
+    BombCutSoundEffectManager_HandleNoteWasCut(self, noteController, noteCutInfo);
+  }
+}
+
 void InstallBadNoteCutEffectSpawnerHooks() {
   INSTALL_HOOK(NELogger::Logger, BadNoteCutEffectSpawner_HandleNoteWasCut);
+  INSTALL_HOOK(NELogger::Logger, BombCutSoundEffectManager_HandleNoteWasCut);
 }
 NEInstallHooks(InstallBadNoteCutEffectSpawnerHooks);

--- a/src/Hooks/FakeNotes/BeatmapData.cpp
+++ b/src/Hooks/FakeNotes/BeatmapData.cpp
@@ -137,9 +137,9 @@ MAKE_HOOK_MATCH(V3_BeatmapDataLoader_GetBeatmapDataFromSaveData,
     for (auto const& it : key##it->value.GetArray()) {                                                                 \
       auto item = parse(it);                                                                                           \
       auto obj = convert(item);                                                                                        \
+      if (!obj) continue;                                                                                              \
       auto& ad = getAD(obj->customData);                                                                               \
       ad.objectData.fake = true;                                                                                       \
-      if (!obj) continue;                                                                                              \
       customBeatmap->AddBeatmapObjectDataOverride(obj);                                                                \
     }                                                                                                                  \
   }

--- a/src/Hooks/FakeNotes/FakeNoteHelper.cpp
+++ b/src/Hooks/FakeNotes/FakeNoteHelper.cpp
@@ -22,7 +22,7 @@ using namespace GlobalNamespace;
  */
 bool FakeNoteHelper::GetFakeNote(NoteData* noteData) {
   auto customNoteData = il2cpp_utils::try_cast<CustomJSONData::CustomNoteData>(noteData);
-  if (!customNoteData || !customNoteData.value()->customData->value) {
+  if (!customNoteData || !customNoteData.value()->customData) {
     return false;
   }
   BeatmapObjectAssociatedData& ad = getAD(customNoteData.value()->customData);
@@ -31,7 +31,7 @@ bool FakeNoteHelper::GetFakeNote(NoteData* noteData) {
 
 bool FakeNoteHelper::GetCuttable(NoteData* noteData) {
   auto customNoteData = il2cpp_utils::try_cast<CustomJSONData::CustomNoteData>(noteData);
-  if (!customNoteData || !customNoteData.value()->customData->value) {
+  if (!customNoteData || !customNoteData.value()->customData) {
     return true;
   }
   BeatmapObjectAssociatedData& ad = getAD(customNoteData.value()->customData);
@@ -40,10 +40,10 @@ bool FakeNoteHelper::GetCuttable(NoteData* noteData) {
 
 bool FakeNoteHelper::GetAttractableArc(SliderData* arcData) {
   auto customArcData = il2cpp_utils::try_cast<CustomJSONData::CustomSliderData>(arcData);
-  if (!customArcData || !customArcData.value()->customData->value) {
+  if (!customArcData || !customArcData.value()->customData) {
     return true;
   }
-  BeatmapObjectAssociatedData& ad = getAD(customArcData.value()->customData);\
+  BeatmapObjectAssociatedData& ad = getAD(customArcData.value()->customData);
   return !ad.objectData.uninteractable.value_or(false);
 }
 


### PR DESCRIPTION
Looks like fake stuff is missing customData->value. Anyways getAD doesnt even use that so checking if it's there makes no sense.